### PR TITLE
Added .prettierignore and moved to yarn in npm scripts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.cache/
+public/

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "scripts": {
     "postinstall": "netlify-lambda install",
     "build:lambda": "netlify-lambda build functions",
-    "build": "npm run build:lambda && gatsby build",
+    "build": "yarn build:lambda && gatsby build",
     "dev": "gatsby develop",
-    "start": "npm run dev",
+    "start": "yarn dev",
     "format": "prettier --write \"**/*.js{,on}\" \"**/*.md\"",
     "lint:eslint": "eslint ."
   },


### PR DESCRIPTION
- Prettier was not ignore the cache and prod files which caused it to run on a lot more files than nessessary
- I moved the package.json file script to yarn as I found a `yarn.lock` file in the repo